### PR TITLE
修改了常驻通知的优先级为最低

### DIFF
--- a/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
+++ b/app/src/main/java/me/crafter/android/zjsnviewer/TimerService.java
@@ -78,6 +78,7 @@ public class TimerService extends Service {
                 .setContentTitle(title)
                 .setContentText(text)
                 .setStyle(style)
+                .setPriority(NotificationCompat.PRIORITY_MIN)
                 .setGroup(Storage.NOTIFICATION_GROUP_KEY)
                 .setGroupSummary(true)
                 .setContentIntent(Storage.getInfoIntent(context));


### PR DESCRIPTION
这样在安卓Lollipop上通知图标不会显示在通知栏上，切通知会被单独分组，常驻通知最好是被设置成PRIORITY_MIN